### PR TITLE
fix: Fastboot ?fastboot=false assertion hit

### DIFF
--- a/addon/services/page-title-list.js
+++ b/addon/services/page-title-list.js
@@ -208,6 +208,15 @@ export default class PageTitleListService extends Service {
     if (isFastBoot) {
       this.updateFastbootTitle(toBeTitle);
     } else {
+      /**
+       * When rendering app with "?fastboot=false" (http://ember-fastboot.com/docs/user-guide#disabling-fastboot)
+       * We will not have <title> element present in DOM.
+       *
+       * But this is fine as by HTML spec,
+       * one is created upon assigning "document.title" value;
+       *
+       * https://html.spec.whatwg.org/multipage/dom.html#dom-tree-accessors
+       */
       this.document.title = toBeTitle;
     }
   }
@@ -223,8 +232,8 @@ export default class PageTitleListService extends Service {
       return;
     }
     assert(
-      "[ember-page-title]: Multiple or no <title> element(s) found. Check for other addons like ember-cli-head updating <title> as well.",
-      document.head.querySelectorAll('title').length === 1
+      "[ember-page-title]: Multiple title elements found. Check for other addons like ember-cli-head updating <title> as well.",
+      document.head.querySelectorAll('title').length <= 1
     );
   }
 

--- a/tests/acceptance/posts-test.js
+++ b/tests/acceptance/posts-test.js
@@ -86,4 +86,12 @@ module('Acceptance: title', function(hooks) {
 
     assert.equal(getPageTitle(), '(10) Reader | My App');
   });
+
+  test('does not throw if no title element exist', async function (assert) {
+    document.head.querySelectorAll('title').forEach((titleElement) => {
+      document.head.removeChild(titleElement);
+    });
+    await visit('/posts');
+    assert.equal(getPageTitle(), 'Posts | My App');
+  });
 });


### PR DESCRIPTION
This PR loosens checks for title elements assertion do avoid Fastboot with `?fastboot=false` render app throwing an exception.

This is fine for this edge case, because once `document.title` is assigned and there is no title element, one is created according to HTML spec - https://html.spec.whatwg.org/multipage/dom.html#dom-tree-accessors - see `If the document element is in the HTML namespace` section.

Follow up for #195.