### PR TITLE
Allow a whitespace string to be a separator

### DIFF
--- a/addon/services/page-title-list.js
+++ b/addon/services/page-title-list.js
@@ -1,7 +1,7 @@
 import { getOwner } from '@ember/application';
 import { scheduleOnce } from '@ember/runloop';
 import Service, { inject as service } from '@ember/service';
-import { isPresent } from '@ember/utils';
+import { isEmpty } from '@ember/utils';
 import { assign } from '@ember/polyfills';
 import { assert } from '@ember/debug';
 
@@ -44,7 +44,7 @@ export default class PageTitleListService extends Service {
     let config = getOwner(this).resolveRegistration('config:environment');
     if (config.pageTitle) {
       ['separator', 'prepend', 'replace'].forEach((key) => {
-        if (isPresent(config.pageTitle[key])) {
+        if (!isEmpty(config.pageTitle[key])) {
           this._defaultConfig[key] = config.pageTitle[key];
         }
       });

--- a/tests/unit/services/page-title-list-test.js
+++ b/tests/unit/services/page-title-list-test.js
@@ -223,4 +223,16 @@ module('service:page-title-list', function(hooks) {
     assert.equal(list._defaultConfig.replace, null);
   });
 
+  test("separator config option can be a whitespace string", function (assert) {
+    this.owner.register("config:environment", {
+      pageTitle: {
+        separator: " ",
+      }
+    });
+
+    let list = this.owner.lookup('service:page-title-list');
+
+    assert.equal(list._defaultConfig.separator, ' ');
+  });
+
 });


### PR DESCRIPTION
Updates the page-title-list service to allow whitespace strings as a valid separator.