### PR TITLE
chore: Use willDestroy() instead of destroy() in helper for teardown.

### DIFF
--- a/addon/helpers/page-title.js
+++ b/addon/helpers/page-title.js
@@ -33,7 +33,8 @@ export default class PageTitle extends Helper {
     return '';
   }
 
-  destroy() {
+  willDestroy() {
+    super.willDestroy();
     this.tokens.remove(this.tokenId);
     this.tokens.scheduleTitleUpdate();
   }


### PR DESCRIPTION
Previous implementation did not call super.destroy() which means potentially some of super class functionality was not executed.

From lifecycle perspective willDestroy() is better suited for teardown.

Closes: #210 