### PR TITLE
Fixed title contents from page-title-list not being tracked

### DIFF
--- a/addon/services/page-title-list.js
+++ b/addon/services/page-title-list.js
@@ -2,6 +2,7 @@ import { getOwner } from '@ember/application';
 import { scheduleOnce } from '@ember/runloop';
 import Service, { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 
 let isFastBoot = typeof FastBoot !== 'undefined';
@@ -26,7 +27,7 @@ export default class PageTitleListService extends Service {
   @service('-document')
   document;
 
-  tokens = [];
+  @tracked tokens = [];
 
   _defaultConfig = {
     // The default separator to use between tokens.


### PR DESCRIPTION
Hello, I saw the issue is described in #37, the issue was closed but the problem seems to be still present.

I encountered this issue right now. The problem is that the `tracked` propery in `page-title-list` service is not tracked, thus the templates that access the title do not get updated. The PR seems to fix this.
