### PR TITLE
Prevent page title to set to empty string

### DIFF
--- a/addon/src/services/page-title.js
+++ b/addon/src/services/page-title.js
@@ -204,6 +204,11 @@ export default class PageTitleService extends Service {
   _updateTitle() {
     const toBeTitle = this.toString();
 
+    if (!toBeTitle) {
+      // Do not set the title to empty string
+      return;
+    }
+    
     if (isFastBoot) {
       this.updateFastbootTitle(toBeTitle);
     } else {


### PR DESCRIPTION
fix: Do not update the title if it is empty