### PR TITLE
Add support & ember-exam for Ember 4.8-lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ember-try-scenario: [ember-release, ember-beta]
+        ember-try-scenario: [ember-lts-4.8, ember-release, ember-beta]
         allow-failure: [false]
         include:
           - ember-try-scenario: ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ember-try-scenario: [ember-lts-4.8, ember-release, ember-beta]
+        ember-try-scenario:
+          [ember-lts-4.8, ember-lts-4.12, ember-release, ember-beta]
         allow-failure: [false]
         include:
           - ember-try-scenario: ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,14 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          [ember-lts-4.8, ember-lts-4.12, ember-release, ember-beta]
+          [
+            ember-lts-3.28,
+            ember-lts-4.4,
+            ember-lts-4.8,
+            ember-lts-4.12,
+            ember-release,
+            ember-beta,
+          ]
         allow-failure: [false]
         include:
           - ember-try-scenario: ember-canary

--- a/addon/src/services/page-title.ts
+++ b/addon/src/services/page-title.ts
@@ -1,4 +1,8 @@
-import { getOwner } from '@ember/owner';
+import {
+  dependencySatisfies,
+  importSync,
+  macroCondition,
+} from '@embroider/macros';
 import { scheduleOnce } from '@ember/runloop';
 import Service, { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
@@ -6,6 +10,15 @@ import { assert } from '@ember/debug';
 import RouterService from '@ember/routing/router-service';
 import SimpleDomDocument from '@simple-dom/document';
 import type Owner from '@ember/owner';
+
+type ownerImport = { getOwner: (context: unknown) => Owner | undefined };
+let getOwner: ownerImport['getOwner'];
+
+if (macroCondition(dependencySatisfies('ember-source', '>=5.0.0'))) {
+  getOwner = (importSync('@ember/owner') as ownerImport).getOwner;
+} else {
+  getOwner = (importSync('@ember/application') as ownerImport).getOwner;
+}
 
 const isFastBoot = typeof FastBoot !== 'undefined';
 

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -21,6 +21,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0',
+            '@ember/test-helpers': '^2.4.2',
           },
         },
       },

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -10,7 +10,9 @@ module.exports = async function () {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0',
+            'ember-source': '~3.28.3',
+            'ember-cli': '~3.28.0',
+            '@ember/test-helpers': '^2.4.2',
           },
         },
       },

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -15,6 +15,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -7,6 +7,14 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -7,6 +7,22 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
+        name: 'ember-lts-3.28',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.4.0',
+          },
+        },
+      },
+      {
         name: 'ember-lts-4.8',
         npm: {
           devDependencies: {


### PR DESCRIPTION
- .github/workflows/ci: add ember 4.8 lts to required tests
- addon/src/services/page-title: add conditional import for getOwner depending on ember version
- test-app/config/ember-try: add ember 4.8 lts configuration to test list