### PR TITLE
Re-export `pageTitle` from index

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -58,6 +58,18 @@ module.exports = function (environment) {
 };
 ```
 
+For usage in `gts` and `gjs`, the `pageTitle` helper is exported from the index:
+
+```gjs
+import { pageTitle } from 'ember-page-title';
+
+<template>
+  {{pageTitle "About"}}
+  
+  ...
+</template>
+```
+
 ### `page-title` Service
 
 If you want to be notified when the page title has been updated, you can extend and override the `page-title` service and provide your own `titleDidUpdate` hook. The `titleDidUpdate` hook receives the new title as its sole argument.

--- a/addon/rollup.config.js
+++ b/addon/rollup.config.js
@@ -15,6 +15,7 @@ export default {
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
     addon.publicEntrypoints([
+      'index.js',
       'helpers/**/*.js',
       'services/**/*.js',
       'test-support/index.js',

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -1,0 +1,1 @@
+export { default as pageTitle } from './helpers/page-title';


### PR DESCRIPTION
For sweeter usage from `gjs`/`gts` file, especially since [`ember-route-template`](https://github.com/discourse/ember-route-template) exists now, you can write this:

```gjs
import { pageTitle } from 'ember-page-title';

<template>
  {{pageTitle "About"}}
  
  ...
</template>
```


because nobody has time for this:

```gjs
import pageTitle from 'ember-page-title/helpers/page-title';

<template>
  {{pageTitle "About"}}
  
  ...
</template>
```

which also feels like calling internal, forbidden API (though, yeah I know isn't - but still _feels_ like).