### PR TITLE
Add the last v4 to ember-try

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           [
             ember-lts-3.28,
             ember-lts-4.4,
+            ember-lts-4.12,
             ember-release,
             ember-beta,
             ember-classic,

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -24,6 +24,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
I had to change _something_ to see if Ci is presently green, so I figured adding the last v4 in the series would be good to have.