### PR TITLE
Declare peerDependencies

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -36,6 +36,9 @@
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0"
   },
+  "peerDependencies": {
+    "ember-source": ">= 3.28.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.16.12",
     "@babel/plugin-proposal-class-properties": "^7.16.7",


### PR DESCRIPTION
this repo currently uses yarn@v1, which allows for a bunch of bad things, like not declaring peers. 

_if you import it, you must declare it_.