### PR TITLE
Prevent CI from running twice on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
 
 jobs:
   lint:


### PR DESCRIPTION
I noticed on https://github.com/ember-cli/ember-page-title/pull/275
CI was running twice.

This should fix that.