### PR TITLE
We don't need to test against different node versions as we have no build behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         browser: [chrome, firefox]
-        node: ['16', '18']
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: ${{ matrix.node }}
       - name: Test
         run: pnpm test:ember --launch ${{ matrix.browser }}
         working-directory: test-app

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release-it": "^16.1.5"
   },
   "volta": {
-    "node": "16.20.2",
+    "node": "20.10.0",
     "pnpm": "8.10.0"
   },
   "publishConfig": {


### PR DESCRIPTION
- removes node in test matrix
- sets development node to v20