### PR TITLE
fix(types): add typesVersions map

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -39,6 +39,13 @@
     },
     "./addon-main.js": "./addon-main.js"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./declarations/*.d.ts"
+      ]
+    }
+  },
   "files": [
     "addon-main.js",
     "dist",


### PR DESCRIPTION
To allow consumers who are still on "moduleResolution": "node" in their TS config (i.e. where TS does not use exports) to resolve the types correctly.