### PR TITLE
Resolve inject deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       matrix:
         ember-try-scenario:
           [
-            minimum-supported-4-1,
+            minimum-supported-4-2,
             ember-lts-4.4,
             ember-lts-4.12,
             ember-lts-5.12,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       matrix:
         ember-try-scenario:
           [
-            minimum-supported-4-1
+            minimum-supported-4-1,
             ember-lts-4.4,
             ember-lts-4.12,
             ember-lts-5.12,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       matrix:
         ember-try-scenario:
           [
-            minimum-supported
+            minimum-supported-4-1
             ember-lts-4.4,
             ember-lts-4.12,
             ember-lts-5.12,

--- a/addon/README.md
+++ b/addon/README.md
@@ -10,9 +10,7 @@ ember install ember-page-title
 
 ### Compatibility
 
-- Ember.js v3.28 or above
-- Ember CLI v3.28 or above
-- Node.js v14 or above
+- `ember-source` v4.1 or above
 
 <details>
 <summary>Fastboot vs Non-Fastboot Notes</summary>

--- a/addon/README.md
+++ b/addon/README.md
@@ -10,7 +10,7 @@ ember install ember-page-title
 
 ### Compatibility
 
-- `ember-source` v4.1 or above
+- `ember-source` v4.2 or above
 
 <details>
 <summary>Fastboot vs Non-Fastboot Notes</summary>

--- a/addon/package.json
+++ b/addon/package.json
@@ -67,7 +67,7 @@
     "@simple-dom/document": "^1.4.0"
   },
   "peerDependencies": {
-    "ember-source": ">= 3.28.0"
+    "ember-source": ">= 4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",

--- a/addon/src/helpers/page-title.ts
+++ b/addon/src/helpers/page-title.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 import { guidFor } from '@ember/object/internals';
 

--- a/addon/src/services/page-title.ts
+++ b/addon/src/services/page-title.ts
@@ -1,5 +1,5 @@
 import { scheduleOnce } from '@ember/runloop';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import { assert } from '@ember/debug';
 import type ApplicationInstance from '@ember/application/instance';

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -10,7 +10,7 @@ module.exports = async function () {
         name: 'minimum-supported',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0',
+            'ember-source': '~4.4.0',
             'ember-cli': '~4.12.0',
           },
         },

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -11,7 +11,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.28.0',
-            'ember-cli': '~3.28.0',
+            'ember-cli': '~4.12.0',
           },
         },
       },
@@ -20,7 +20,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0',
-            'ember-cli': '~4.4.0',
+            'ember-cli': '~4.12.0',
           },
         },
       },

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -10,7 +10,7 @@ module.exports = async function () {
         name: 'minimum-supported',
         npm: {
           devDependencies: {
-            'ember-source': '~4.4.0',
+            'ember-source': '~4.1.0',
             'ember-cli': '~4.12.0',
           },
         },

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -7,10 +7,10 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'minimum-supported-4-1',
+        name: 'minimum-supported-4-2',
         npm: {
           devDependencies: {
-            'ember-source': '~4.1.0',
+            'ember-source': '~4.2.0',
             'ember-cli': '~4.12.0',
           },
         },

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -7,7 +7,7 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'minimum-supported',
+        name: 'minimum-supported-4-1',
         npm: {
           devDependencies: {
             'ember-source': '~4.1.0',


### PR DESCRIPTION
Minimum ember-source this library can support now is: 4.2.0, see: https://github.com/emberjs/rfcs/blob/master/text/0752-inject-service.md


