### PR TITLE
Fixed multiple custom separators

### DIFF
--- a/addon/src/services/page-title.ts
+++ b/addon/src/services/page-title.ts
@@ -203,11 +203,6 @@ export default class PageTitleService extends Service {
           group = [];
           groups.push(group);
         }
-        const lastToken = group[0];
-        if (lastToken) {
-          token = { ...token };
-          token.separator = lastToken.separator;
-        }
         group.unshift(token);
       } else {
         if (!appending) {

--- a/test-app/app/router.js
+++ b/test-app/app/router.js
@@ -8,6 +8,7 @@ export default class Router extends EmberRouter {
 
 Router.map(function () {
   this.route('about', function () {
+    this.route('policies');
     this.route('authors', function () {
       this.route('profile');
     });

--- a/test-app/app/templates/about/policies.hbs
+++ b/test-app/app/templates/about/policies.hbs
@@ -1,0 +1,2 @@
+{{page-title 'Policy' separator=" * "}}
+{{page-title 'Terms' separator=" + "}}

--- a/test-app/tests/acceptance/posts-test.js
+++ b/test-app/tests/acceptance/posts-test.js
@@ -31,6 +31,12 @@ module('Acceptance: title', function (hooks) {
     assert.strictEqual(getPageTitle(), 'Profile > Authors > About My App');
   });
 
+  test('multiple custom separators work', async function (assert) {
+    await visit('/about/policies');
+
+    assert.strictEqual(getPageTitle(), 'Terms + Policy * About My App');
+  });
+
   test('multiple components in a row work', async function (assert) {
     await visit('/posts/rails-is-omakase');
 

--- a/test-app/tests/unit/services/page-title-test.js
+++ b/test-app/tests/unit/services/page-title-test.js
@@ -69,8 +69,9 @@ module('service:page-title', function (hooks) {
     list.push(first);
     list.push(second);
 
-    assert.strictEqual(first.separator, 'a');
-    assert.strictEqual(second.separator, 'a');
+    let tokens = list.get('sortedTokens');
+    assert.strictEqual(tokens[0].separator, 'a');
+    assert.strictEqual(tokens[1].separator, 'a');
   });
 
   test('the separator property is not inherited if explicitly set', function (assert) {
@@ -81,8 +82,9 @@ module('service:page-title', function (hooks) {
     list.push(first);
     list.push(second);
 
-    assert.strictEqual(first.separator, 'a');
-    assert.strictEqual(second.separator, 'b');
+    let tokens = list.get('sortedTokens');
+    assert.strictEqual(tokens[0].separator, 'b');
+    assert.strictEqual(tokens[1].separator, 'a');
   });
 
   test('the prepend property is inherited by the previous token', function (assert) {


### PR DESCRIPTION
I've had trouble chaining multiple custom separators, and I tracked it down to this code in `sortedTokens` that always copies  the separator from the previous token in the group overriding any customization. Given that the separator default & inheritance logic is done in `push(..)`, specifically by `inheritFromPrevious` and `applyTokenDefaults`, I've found that the `lastToken` logic in `sortedTokens` was a bug.