### PR TITLE
Node is now 24

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -96,9 +96,6 @@
     "rollup": "^4.9.1",
     "typescript": "^5.3.3"
   },
-  "engines": {
-    "node": "16.* || >= 18"
-  },
   "ember-addon": {
     "demoURL": "https://ember-cli.github.io/ember-page-title",
     "main": "addon-main.js",

--- a/docs/package.json
+++ b/docs/package.json
@@ -85,7 +85,7 @@
     "webpack": "^5.0.0"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": ">= 24"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release-plan": "^0.6.0"
   },
   "volta": {
-    "node": "20.10.0",
+    "node": "24.14.0",
     "pnpm": "8.10.0"
   },
   "publishConfig": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -82,7 +82,7 @@
     "webpack": "^5.0.0"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": ">= 24"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This is dev/ci and not a requirement for users. 

Ember's officially supported node now requires `require(esm)`, so bumping to 24 is an easy way to get that