### PR TITLE
Set allow-failure on every try scenario

### DIFF
--- a/test-app/.try.mjs
+++ b/test-app/.try.mjs
@@ -35,6 +35,7 @@ export default {
   scenarios: [
     {
       name: 'min-supported',
+      'allow-failure': false,
       npm: {
         devDependencies: {
           'ember-source': '~4.2.0',
@@ -49,6 +50,7 @@ export default {
     },
     {
       name: 'ember-lts-4.12',
+      'allow-failure': false,
       npm: {
         devDependencies: {
           'ember-source': '~4.12.0',
@@ -63,6 +65,7 @@ export default {
     },
     {
       name: 'ember-lts-5.12',
+      'allow-failure': false,
       npm: {
         devDependencies: {
           'ember-source': '~5.12.0',
@@ -76,6 +79,7 @@ export default {
     },
     {
       name: `ember-lts-6.4`,
+      'allow-failure': false,
       npm: {
         devDependencies: {
           'ember-source': `npm:ember-source@~6.4.0`,
@@ -84,6 +88,7 @@ export default {
     },
     {
       name: `ember-latest`,
+      'allow-failure': false,
       npm: {
         devDependencies: {
           'ember-source': `npm:ember-source@latest`,
@@ -92,6 +97,7 @@ export default {
     },
     {
       name: `ember-beta`,
+      'allow-failure': true,
       npm: {
         devDependencies: {
           'ember-source': `npm:ember-source@beta`,
@@ -100,6 +106,7 @@ export default {
     },
     {
       name: `ember-alpha`,
+      'allow-failure': true,
       npm: {
         devDependencies: {
           'ember-source': `npm:ember-source@alpha`,


### PR DESCRIPTION
## Summary

Fixes the silent failure on the `Vite` branch where the `try-scenarios` job never appears in the CI run but the overall run is marked `failure`.

The workflow has:

```yaml
try-scenarios:
  continue-on-error: ${{ matrix.allow-failure }}
  ...
  strategy:
    fail-fast: false
    matrix: ${{fromJson(needs.build_matrix.outputs.matrix)}}
```

`@embroider/try`'s `list` command passes scenario objects through almost verbatim (only `env: {}` is defaulted in). Since none of the scenarios in `test-app/.try.mjs` defined `allow-failure`, `${{ matrix.allow-failure }}` evaluated to `''`, which GitHub Actions rejects as a non-boolean. The annotation on run [`24614721563`](https://github.com/ember-cli/ember-page-title/actions/runs/24614721563) confirms:

> Error when evaluating 'continue-on-error' for job 'try-scenarios'. .github/workflows/ci.yml (Line: 170, Col: 24): Unexpected value ''

Because the matrix failed to materialize, no try-scenarios job was created, yet the workflow run was marked `failure` — which is why the 13 visible checks are all green while the PR shows red.

This PR defines `allow-failure` on every scenario: `true` for the bleeding-edge `ember-beta` and `ember-alpha` scenarios, `false` everywhere else.

## Test plan

- [ ] CI on this PR shows the `try-scenarios` jobs (min-supported, ember-lts-4.12, ember-lts-5.12, ember-lts-6.4, ember-latest, ember-beta, ember-alpha) actually get created
- [ ] Annotation about `continue-on-error` evaluating to `''` no longer appears
- [ ] Overall workflow conclusion matches the visible check results

🤖 Generated with [Claude Code](https://claude.com/claude-code)