### PR TITLE
Bump @ember/test-helpers to ^4 in ember4 try scenarios

### DIFF
--- a/test-app/.try.mjs
+++ b/test-app/.try.mjs
@@ -17,8 +17,8 @@ module.exports = async function (defaults) {
 };
 
   const ember4 = {
-    '@ember/test-helpers': '^3.2.1',
-    '@ember/test-waiters': '^3.0.0',
+    '@ember/test-helpers': '^4.0.0',
+    '@ember/test-waiters': '^3.1.0',
     '@embroider/compat': '^4.0.3',
     'ember-qunit': '^8.0.0',
     'ember-cli': '~4.12.0',


### PR DESCRIPTION
## Summary

Fixes the remaining `min-supported` and `ember-lts-4.12` try-scenario failures on #317:

```
[vite]: Rollup failed to resolve import "require" from
".../@ember/test-helpers/-internal/build-registry.js"
```

### Root cause

`@ember/test-helpers@3.x` ([`addon-test-support/@ember/test-helpers/-internal/build-registry.ts:6`](https://github.com/emberjs/ember-test-helpers/blob/v3.3.1/addon-test-support/%40ember/test-helpers/-internal/build-registry.ts#L6)) starts with:

```ts
import require, { has } from 'require';
```

This is the AMD-loader `require` module — a magic identifier provided at runtime by classic Ember's `loader.js`. After `@embroider/compat` rewrites the package into `.embroider/rewritten-packages/...`, vite/rollup sees a plain bare import `require` with no matching module and fails. Both `min-supported` and `ember-lts-4.12` hit this because the `ember4` deps stanza in `test-app/.try.mjs` pins `@ember/test-helpers: ^3.2.1`.

### Fix

`@ember/test-helpers@4.0.0` dropped the loader.js `require` import and reimplemented `build-registry` on top of `@ember/-internals/container` and `./-owner-mixin-imports.js`. Its peer is `ember-source >= 4.0.0`, which covers both `min-supported` (`~4.2.0`) and `ember-lts-4.12`. `ember-qunit@^8.0.0`'s peer is `@ember/test-helpers: >=3.0.3`, so bumping to `^4.0.0` stays within bounds.

```diff
 const ember4 = {
-  '@ember/test-helpers': '^3.2.1',
-  '@ember/test-waiters': '^3.0.0',
+  '@ember/test-helpers': '^4.0.0',
+  '@ember/test-waiters': '^3.1.0',
   '@embroider/compat': '^4.0.3',
   'ember-qunit': '^8.0.0',
   'ember-cli': '~4.12.0',
 };
```

(`test-waiters` bumped to `^3.1.0` to stay within the window test-helpers 4 expects.)

## Test plan

- [ ] `min-supported` and `ember-lts-4.12` scenarios go green
- [ ] Other scenarios (which don't apply the `ember4` overrides) remain unaffected — they already use test-helpers from the test-app's own `^5.4.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)