### PR TITLE
Polyfill @ember/owner imports for min-supported scenario

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       babel-plugin-debug-macros:
         specifier: ^0.3.4
         version: 0.3.4(@babel/core@7.29.0)
+      babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner:
+        specifier: ^1.0.4
+        version: 1.0.4(@babel/core@7.29.0)
       babel-plugin-ember-template-compilation:
         specifier: ^3.1.0
         version: 3.1.0
@@ -2160,6 +2163,11 @@ packages:
   babel-plugin-ember-modules-api-polyfill@3.5.0:
     resolution: {integrity: sha512-pJajN/DkQUnStw0Az8c6khVcMQHgzqWr61lLNtVeu0g61LRW0k9jyK7vaedrHDWGe/Qe8sxG5wpiyW9NsMqFzA==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner@1.0.4:
+    resolution: {integrity: sha512-kZQdMKC0Ec+SsDZ/Lv/Ic1f23FJkZI5rDjRz+00l3JWbEeU9/tex0aCYs16VvuT1O1XG8c3xJNx6+ZXliBkYPQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   babel-plugin-ember-template-compilation@3.1.0:
     resolution: {integrity: sha512-kk7cGyblE9n4MB98rqw2wuUW7YLD5FM+Tr97gNSYL4e8DBMQndLuWaWNx1wfd7o00NjFhhoTR+HZs2nj23g2Lw==}
@@ -7745,6 +7753,10 @@ snapshots:
   babel-plugin-ember-modules-api-polyfill@3.5.0:
     dependencies:
       ember-rfc176-data: 0.3.18
+
+  babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner@1.0.4(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
 
   babel-plugin-ember-template-compilation@3.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@rollup/plugin-babel':
         specifier: ^6.1.0
         version: 6.1.0(@babel/core@7.29.0)(rollup@4.60.1)
+      babel-plugin-debug-macros:
+        specifier: ^0.3.4
+        version: 0.3.4(@babel/core@7.29.0)
       babel-plugin-ember-template-compilation:
         specifier: ^3.1.0
         version: 3.1.0

--- a/test-app/.try.mjs
+++ b/test-app/.try.mjs
@@ -17,10 +17,10 @@ module.exports = async function (defaults) {
 };
 
   const ember4 = {
-    '@ember/test-helpers': '^4.0.0',
+    '@ember/test-helpers': '^5.0.0',
     '@ember/test-waiters': '^3.1.0',
     '@embroider/compat': '^4.0.3',
-    'ember-qunit': '^8.0.0',
+    'ember-qunit': '^9.0.0',
     'ember-cli': '~4.12.0',
   };
 

--- a/test-app/babel.config.mjs
+++ b/test-app/babel.config.mjs
@@ -54,6 +54,7 @@ export default {
               flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
             },
           ],
+          'babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner',
         ]
       : []),
   ],

--- a/test-app/babel.config.mjs
+++ b/test-app/babel.config.mjs
@@ -4,6 +4,8 @@ import { buildMacros } from '@embroider/macros/babel';
 
 const macros = buildMacros();
 
+const isCompatBuild = !!process.env.ENABLE_COMPAT_BUILD;
+
 export default {
   plugins: [
     [
@@ -44,6 +46,16 @@ export default {
       },
     ],
     ...macros.babelMacros,
+    ...(isCompatBuild
+      ? [
+          [
+            'babel-plugin-debug-macros',
+            {
+              flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
+            },
+          ],
+        ]
+      : []),
   ],
 
   generatorOpts: {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -35,6 +35,7 @@
     "@babel/eslint-parser": "^7.23.3",
     "@babel/plugin-transform-runtime": "^7.29.0",
     "@babel/plugin-transform-typescript": "^7.28.6",
+    "babel-plugin-debug-macros": "^0.3.4",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^5.4.1",
     "@embroider/core": "^4.4.7",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -36,6 +36,7 @@
     "@babel/plugin-transform-runtime": "^7.29.0",
     "@babel/plugin-transform-typescript": "^7.28.6",
     "babel-plugin-debug-macros": "^0.3.4",
+    "babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner": "^1.0.4",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^5.4.1",
     "@embroider/core": "^4.4.7",


### PR DESCRIPTION
## Summary

> Stacks on top of #322. Merge that first.

Unblocks the `min-supported` try-scenario. With the `babel-plugin-debug-macros` fix from #322 in place, `min-supported` (ember-source `~4.2.0`) now fails at:

```
[vite]: Rollup failed to resolve import "@ember/owner" from
".../@glimmer/component@2.1.1/node_modules/@glimmer/component/dist/index.js"
```

`@glimmer/component@2.1.1` has `import { setOwner } from '@ember/owner';`. `@ember/owner` as an importable module path didn't exist until ember-source 4.10 (per the [`@ember/application` → `@ember/owner` split deprecation](https://deprecations.emberjs.com/v4.x)), so there's no resolution on Ember 4.2. Per the upstream polyfill [README](https://github.com/NullVoxPopuli/ember-polyfill-get-and-set-owner-from-ember-owner): "not needed if you are on ember-source 4.12 or newer."

**Fix**: add [`babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner`](https://github.com/NullVoxPopuli/ember-polyfill-get-and-set-owner-from-ember-owner) (by NullVoxPopuli) to `babel.config.mjs`, next to `babel-plugin-debug-macros` and under the same `ENABLE_COMPAT_BUILD` gate. It rewrites:

- `import { getOwner } from '@ember/owner'` → `import { getOwner } from '@ember/application'`
- `import { setOwner } from '@ember/owner'` → `import { setOwner } from '@ember/application'`

`@ember/application` exports both symbols in every 4.x release, so the rewrite works on Ember 4.2 and remains a semantic no-op on 4.12+ (where `@ember/application` re-exports from `@ember/owner`).

```diff
     ...(isCompatBuild
       ? [
           [
             'babel-plugin-debug-macros',
             {
               flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
             },
           ],
+          'babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner',
         ]
       : []),
```

## Test plan

- [x] `min-supported` (ember-source `~4.2.0`) locally → 31 pass, 0 fail
- [x] Default non-compat → 31 pass, 0 fail (plugin not added without `ENABLE_COMPAT_BUILD`)
- [ ] `min-supported` job on CI goes green
- [ ] `ember-lts-4.12`, `ember-lts-5.12`, `ember-lts-6.4`, `ember-latest`, `ember-beta`, `ember-alpha` remain green — `setOwner` resolution is unchanged for them; the rewrite targets `@ember/application` which re-exports from `@ember/owner` in those Ember versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)