### PR TITLE
Don't run @ember/owner polyfill on ember-source itself

### DIFF
--- a/test-app/babel.config.mjs
+++ b/test-app/babel.config.mjs
@@ -54,10 +54,21 @@ export default {
               flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
             },
           ],
-          'babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner',
         ]
       : []),
   ],
+
+  overrides: isCompatBuild
+    ? [
+        {
+          test: (filename) =>
+            filename !== undefined && !filename.includes('/ember-source/'),
+          plugins: [
+            'babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner',
+          ],
+        },
+      ]
+    : [],
 
   generatorOpts: {
     compact: false,


### PR DESCRIPTION
## Summary

Fixes the regression on `ember-lts-4.12` introduced by #323:

```
Uncaught ReferenceError: Cannot access 'getOwner' before initialization
at http://localhost:.../assets/app-*.js, line N
```

### Root cause

ember-source `>= 4.12`'s [`@ember/application/index.js`](https://github.com/emberjs/ember.js/blob/v4.12.4/packages/%40ember/application/index.ts) re-exports `getOwner`/`setOwner` from `@ember/owner` under aliases, then reassigns them as `const`s:

```js
import {
  getOwner as actualGetOwner,
  setOwner as actualSetOwner,
} from '@ember/owner';

export const getOwner = actualGetOwner;
export const setOwner = actualSetOwner;
```

`babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner` (added in #323) rewrote the `from '@ember/owner'` at the top of that file to `from '@ember/application'` — the module's own specifier — so rollup bundled it as a self-import. The `const getOwner = actualGetOwner` line then becomes (effectively) `const getOwner = getOwner`, which trips TDZ at load time.

The plugin already tries to skip ember-source files with this guard:

```js
if (state.filename?.includes('/ember-source/')) {
  if (!state.filename.includes('/.embroider/')) {
    return;
  }
}
```

But in a vite compat build ember-source lives at `node_modules/.embroider/rewritten-packages/ember-source.*/node_modules/ember-source/...`, so the path contains **both** `/ember-source/` **and** `/.embroider/` — the guard falls through and rewrites the file. `min-supported` didn't hit this on Ember 4.2 because that version's `@ember/application` doesn't import from `@ember/owner` in the first place.

### Fix

Move the polyfill plugin out of the main `plugins` list into `babel.overrides`, with a `test` filter that skips anything whose filename contains `/ember-source/`:

```diff
     ...macros.babelMacros,
     ...(isCompatBuild
       ? [
           [
             'babel-plugin-debug-macros',
             {
               flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
             },
           ],
-          'babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner',
         ]
       : []),
   ],

+  overrides: isCompatBuild
+    ? [
+        {
+          test: (filename) =>
+            filename !== undefined && !filename.includes('/ember-source/'),
+          plugins: [
+            'babel-plugin-ember-polyfill-get-and-set-owner-from-ember-owner',
+          ],
+        },
+      ]
+    : [],
```

This keeps the rewrite running where it's actually needed (`@glimmer/component@2.1.1`'s `import { setOwner } from '@ember/owner'`, which is what #323 was targeting), and leaves ember-source alone.

A proper fix probably belongs upstream in the plugin (the existing filename guard likely intended to skip ember-source unconditionally), but this unblocks CI without needing a plugin release.

## Test plan

- [x] `ember-lts-4.12` locally → 31 pass, 0 fail
- [x] `min-supported` locally → 31 pass, 0 fail (polyfill still runs on `@glimmer/component`)
- [x] Default non-compat → 31 pass, 0 fail (override block is empty)
- [ ] `ember-lts-4.12` and `min-supported` jobs on CI go green
- [ ] Other try scenarios and the regular Tests/Floating jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)